### PR TITLE
add check.names=FALSE to metadata parsing

### DIFF
--- a/dropletutils-read-10x-counts.R
+++ b/dropletutils-read-10x-counts.R
@@ -83,7 +83,10 @@ if(!is.na(opt$metadata_files)){
   if(is.na(opt$cell_id_column)){
     stop("Cell id column name for metadata files is not provided.")
   }
-  metadata = lapply(metadata_files, function(x) read.csv(x, sep="\t"))
+  metadata = lapply(metadata_files, function(x) 
+                                    read.csv(x, sep="\t",
+                                    check.names=FALSE,
+                                    stringsAsFactors=FALSE))
   common_names = Reduce(intersect, lapply(metadata, colnames))
   metadata = do.call(rbind, lapply(metadata, function(x) x[,common_names]))
 

--- a/dropletutils-read-10x-counts.R
+++ b/dropletutils-read-10x-counts.R
@@ -83,10 +83,14 @@ if(!is.na(opt$metadata_files)){
   if(is.na(opt$cell_id_column)){
     stop("Cell id column name for metadata files is not provided.")
   }
-  metadata = lapply(metadata_files, function(x) 
-                                    read.csv(x, sep="\t",
-                                    check.names=FALSE,
-                                    stringsAsFactors=FALSE))
+  metadata = lapply(metadata_files, function(x) {
+    read.csv(
+      x,
+      sep = "\t",
+      check.names = FALSE,
+      stringsAsFactors = FALSE
+    )
+  })
   common_names = Reduce(intersect, lapply(metadata, colnames))
   metadata = do.call(rbind, lapply(metadata, function(x) x[,common_names]))
 


### PR DESCRIPTION
This PR helps to avoid problems with parsing metadata files. In some cases, spaces or other illegal characters might be present in metadata field names. By default, R puts dots instead of those characters, which complicates things for downstream analyses. To avoid this, we disable this feature.
`NB`: this implies that the `$` is now deprecated in favour of subsetting via `[ ]`.

- Add check.names=FALSE to text files parsing